### PR TITLE
Fixing an incorrect redirect to stderr in test/new.c

### DIFF
--- a/test/new.c
+++ b/test/new.c
@@ -61,7 +61,7 @@ main (int argc, char **argv)
 	    for (j = 0; j < 10; j++)
 	      {
 		attr = NULL;
-		fprintf (stderr, "Creatin a attribute... ");
+		fprintf (stdout, "Creating a attribute... ");
 		ret = nxml_add_attribute (data, item, &attr);
 		check (data, ret);
 


### PR DESCRIPTION
This log message is only printing an info output, so should be pushed to stdout instead of stderr.
Also fixing a typo at the same time.

Thanks!
Joseph