### PR TITLE
Fuzzy fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ test/easy
 test/namespace
 test/new
 test/parser
+test/test_base
 test/write

--- a/src/nxml_parser.c
+++ b/src/nxml_parser.c
@@ -187,6 +187,13 @@ __nxml_parse_get_attr (nxml_t * doc, char **buffer, size_t * size)
 {
   char attr[1024];
   int i;
+
+  /* NOTE, 2020-07-20, Giovanni Simoni, dacav at fastmail dot com.
+   *
+   * 'bytes' and 'ch' seem to be uninitialized, but they are implicitly
+   * assigned by the __NXML_NAMESTARTCHARS macro, which also assumes that
+   * a variable named 'buffer' exists.
+   */
   int byte;
   int64_t ch;
 

--- a/src/nxml_parser.c
+++ b/src/nxml_parser.c
@@ -5,12 +5,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- *
+ * 
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -19,147 +19,172 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #else
-#error Use configure; make; make install
+# error Use configure; make; make install
 #endif
 
 #include "nxml.h"
 
-static int __nxml_parse_unique_attribute(nxml_attr_t *attr, char *name) {
-  /*
+static int
+__nxml_parse_unique_attribute (nxml_attr_t * attr, char *name)
+{
+  /* 
    * Rule [40] - Well-formedness contraint: Unique Att Spec
    */
 
-  while (attr) {
-    if (!strcmp(attr->name, name))
-      return 1;
+  while (attr)
+    {
+      if (!strcmp (attr->name, name))
+	return 1;
 
-    attr = attr->next;
-  }
+      attr = attr->next;
+    }
 
   return 0;
 }
 
-static char *__nxml_parse_string(nxml_t *doc, char *buffer, int size) {
+static char *
+__nxml_parse_string (nxml_t * doc, char *buffer, int size)
+{
   char *real;
   int i;
   int q;
   __nxml_string_t *ret;
 
-  ret = __nxml_string_new();
+  ret = __nxml_string_new ();
 
-  for (q = i = 0; i < size; i++) {
-    if (*(buffer + i) == 0xd)
-      continue;
+  for (q = i = 0; i < size; i++)
+    {
+      if (*(buffer + i) == 0xd)
+	continue;
 
-    if (*(buffer + i) == 0xa || *(buffer + i) == 0x9 || *(buffer + i) == 0x20) {
-      if (!q) {
-        if (!doc->priv.textindent)
-          q = 1;
+      if (*(buffer + i) == 0xa || *(buffer + i) == 0x9
+	  || *(buffer + i) == 0x20)
+	{
+	  if (!q)
+	    {
+	      if (!doc->priv.textindent)
+		q = 1;
 
-        __nxml_string_add(ret, buffer + i, 1);
-      }
+	      __nxml_string_add (ret, buffer + i, 1);
+	    }
+	}
+
+      else if (*(buffer + i) == '&')
+	{
+	  if (!strncmp (buffer + i, "&lt;", 4))
+	    {
+	      __nxml_string_add (ret, "<", 1);
+	      i += 3;
+	      q = 0;
+	    }
+
+	  else if (!strncmp (buffer + i, "&gt;", 4))
+	    {
+	      __nxml_string_add (ret, ">", 1);
+	      i += 3;
+	      q = 0;
+	    }
+
+	  else if (!strncmp (buffer + i, "&amp;", 5))
+	    {
+	      __nxml_string_add (ret, "&", 1);
+	      i += 4;
+	      q = 0;
+	    }
+
+	  else if (!strncmp (buffer + i, "&apos;", 6))
+	    {
+	      __nxml_string_add (ret, "'", 1);
+	      i += 5;
+	      q = 0;
+	    }
+
+	  else if (!strncmp (buffer + i, "&quot;", 6))
+	    {
+	      __nxml_string_add (ret, "\"", 1);
+	      i += 5;
+	      q = 0;
+	    }
+
+	  else if (*(buffer + i + 1) == '#')
+	    {
+	      char buf[1024];
+	      int k = i;
+	      int last;
+
+	      while (*(buffer + k) != ';' && k < size)
+		k++;
+
+	      last = k - (i + 2) > sizeof (buf) ? sizeof (buf) : k - (i + 2);
+	      strncpy (buf, buffer + i + 2, last);
+	      buf[last] = 0;
+
+	      if (buf[0] != 'x')
+		last = atoi (buf);
+	      else
+		last = __nxml_atoi (&buf[1]);
+
+	      if ((last =
+		   __nxml_int_charset (last, (unsigned char *) buf,
+				       doc->encoding)) > 0)
+		__nxml_string_add (ret, buf, last);
+	      else
+		__nxml_string_add (ret, buffer + i, 1);
+
+	      i += k - i;
+	      q = 0;
+	    }
+
+	  else
+	    {
+	      __nxml_entity_t *entity;
+	      char buf[1024];
+	      int k = i;
+	      int last;
+
+	      while (*(buffer + k) != ';' && k < size)
+		k++;
+
+	      last = k - (i + 1) > sizeof (buf) ? sizeof (buf) : k - (i + 1);
+	      strncpy (buf, buffer + i + 1, last);
+	      buf[last] = 0;
+
+	      for (entity = doc->priv.entities; entity; entity = entity->next)
+		{
+		  if (!strcmp (entity->name, buf))
+		    {
+		      __nxml_string_add (ret, entity->entity,
+					 strlen (entity->entity));
+		      break;
+		    }
+
+		}
+
+	      if (!entity)
+		__nxml_string_add (ret, buffer + i, 1);
+	      else
+		i += strlen (entity->name) + 1;
+
+	      q = 0;
+	    }
+	}
+
+      else
+	{
+	  q = 0;
+	  __nxml_string_add (ret, buffer + i, 1);
+	}
     }
 
-    else if (*(buffer + i) == '&') {
-      if (!strncmp(buffer + i, "&lt;", 4)) {
-        __nxml_string_add(ret, "<", 1);
-        i += 3;
-        q = 0;
-      }
-
-      else if (!strncmp(buffer + i, "&gt;", 4)) {
-        __nxml_string_add(ret, ">", 1);
-        i += 3;
-        q = 0;
-      }
-
-      else if (!strncmp(buffer + i, "&amp;", 5)) {
-        __nxml_string_add(ret, "&", 1);
-        i += 4;
-        q = 0;
-      }
-
-      else if (!strncmp(buffer + i, "&apos;", 6)) {
-        __nxml_string_add(ret, "'", 1);
-        i += 5;
-        q = 0;
-      }
-
-      else if (!strncmp(buffer + i, "&quot;", 6)) {
-        __nxml_string_add(ret, "\"", 1);
-        i += 5;
-        q = 0;
-      }
-
-      else if (*(buffer + i + 1) == '#') {
-        char buf[1024];
-        int k = i;
-        int last;
-
-        while (*(buffer + k) != ';' && k < size)
-          k++;
-
-        last = k - (i + 2) > sizeof(buf) ? sizeof(buf) : k - (i + 2);
-        strncpy(buf, buffer + i + 2, last);
-        buf[last] = 0;
-
-        if (buf[0] != 'x')
-          last = atoi(buf);
-        else
-          last = __nxml_atoi(&buf[1]);
-
-        if ((last = __nxml_int_charset(last, (unsigned char *)buf,
-                                       doc->encoding)) > 0)
-          __nxml_string_add(ret, buf, last);
-        else
-          __nxml_string_add(ret, buffer + i, 1);
-
-        i += k - i;
-        q = 0;
-      }
-
-      else {
-        __nxml_entity_t *entity;
-        char buf[1024];
-        int k = i;
-        int last;
-
-        while (*(buffer + k) != ';' && k < size)
-          k++;
-
-        last = k - (i + 1) > sizeof(buf) ? sizeof(buf) : k - (i + 1);
-        strncpy(buf, buffer + i + 1, last);
-        buf[last] = 0;
-
-        for (entity = doc->priv.entities; entity; entity = entity->next) {
-          if (!strcmp(entity->name, buf)) {
-            __nxml_string_add(ret, entity->entity, strlen(entity->entity));
-            break;
-          }
-        }
-
-        if (!entity)
-          __nxml_string_add(ret, buffer + i, 1);
-        else
-          i += strlen(entity->name) + 1;
-
-        q = 0;
-      }
-    }
-
-    else {
-      q = 0;
-      __nxml_string_add(ret, buffer + i, 1);
-    }
-  }
-
-  if (!(real = __nxml_string_free(ret)))
-    real = strdup("");
+  if (!(real = __nxml_string_free (ret)))
+    real = strdup ("");
 
   return real;
 }
 
-static char *__nxml_parse_get_attr(nxml_t *doc, char **buffer, size_t *size) {
+static char *
+__nxml_parse_get_attr (nxml_t * doc, char **buffer, size_t * size)
+{
   char attr[1024];
   int i;
   int byte;
@@ -171,48 +196,52 @@ static char *__nxml_parse_get_attr(nxml_t *doc, char **buffer, size_t *size) {
   if (!__NXML_NAMESTARTCHARS)
     return NULL;
 
-  memcpy(&attr[0], *buffer, byte);
+  memcpy (&attr[0], *buffer, byte);
 
   i = byte;
   (*buffer) += byte;
   (*size) -= byte;
 
-  while (__NXML_NAMECHARS && *size && i < sizeof(attr) - 1) {
-    memcpy(&attr[i], *buffer, byte);
+  while (__NXML_NAMECHARS && *size && i < sizeof (attr) - 1)
+    {
+      memcpy (&attr[i], *buffer, byte);
 
-    i += byte;
-    (*buffer) += byte;
-    (*size) -= byte;
-  }
+      i += byte;
+      (*buffer) += byte;
+      (*size) -= byte;
+    }
 
-  if (**buffer != 0x20 && **buffer != 0x9 && **buffer != 0xa &&
-      **buffer != 0xd && **buffer != '=') {
-    (*buffer) -= i;
-    (*size) += i;
-    return NULL;
-  }
+  if (**buffer != 0x20 && **buffer != 0x9 && **buffer != 0xa
+      && **buffer != 0xd && **buffer != '=')
+    {
+      (*buffer) -= i;
+      (*size) += i;
+      return NULL;
+    }
 
-  i += __nxml_escape_spaces(doc, buffer, size);
+  i += __nxml_escape_spaces (doc, buffer, size);
 
-  if (**buffer != '=') {
-    (*buffer) -= i;
-    (*size) += i;
-    return NULL;
-  }
+  if (**buffer != '=')
+    {
+      (*buffer) -= i;
+      (*size) += i;
+      return NULL;
+    }
 
   (*buffer)++;
   (*size)--;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
   attr[i] = 0;
-  return strdup(attr);
+  return strdup (attr);
 }
 
-static nxml_error_t __nxml_parse_get_attribute(nxml_t *doc, char **buffer,
-                                               size_t *size,
-                                               nxml_attr_t **attr) {
-  /*
+static nxml_error_t
+__nxml_parse_get_attribute (nxml_t * doc, char **buffer, size_t * size,
+			    nxml_attr_t ** attr)
+{
+  /* 
    * Rule [41] - Attribute ::= Name Eq AttValue
    * Rule [25] - Eq ::= S? '=' S?
    * Rule [5]  - Name ::= NameStartChar (NameChar)*
@@ -228,36 +257,39 @@ static nxml_error_t __nxml_parse_get_attribute(nxml_t *doc, char **buffer,
 
   *attr = NULL;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
-  if (!(tag = __nxml_parse_get_attr(doc, buffer, size)))
+  if (!(tag = __nxml_parse_get_attr (doc, buffer, size)))
     return NXML_OK;
 
-  if (!(value = __nxml_get_value(doc, buffer, size))) {
-    free(tag);
+  if (!(value = __nxml_get_value (doc, buffer, size)))
+    {
+      free (tag);
 
-    if (doc->priv.func)
-      doc->priv.func("%s: expected value of attribute (line %d)\n",
-                     doc->file ? doc->file : "", doc->priv.line);
-    return NXML_ERR_PARSER;
-  }
+      if (doc->priv.func)
+	doc->priv.func ("%s: expected value of attribute (line %d)\n",
+			doc->file ? doc->file : "", doc->priv.line);
+      return NXML_ERR_PARSER;
+    }
 
-  if (!(v = __nxml_parse_string(doc, value, strlen(value)))) {
-    free(tag);
-    return NXML_ERR_POSIX;
-  }
+  if (!(v = __nxml_parse_string (doc, value, strlen (value))))
+    {
+      free (tag);
+      return NXML_ERR_POSIX;
+    }
 
-  free(value);
+  free (value);
   value = v;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
-  if (!(*attr = (nxml_attr_t *)calloc(1, sizeof(nxml_attr_t)))) {
-    free(tag);
-    free(value);
+  if (!(*attr = (nxml_attr_t *) calloc (1, sizeof (nxml_attr_t))))
+    {
+      free (tag);
+      free (value);
 
-    return NXML_ERR_POSIX;
-  }
+      return NXML_ERR_POSIX;
+    }
 
   (*attr)->name = tag;
   (*attr)->value = value;
@@ -265,10 +297,12 @@ static nxml_error_t __nxml_parse_get_attribute(nxml_t *doc, char **buffer,
   return NXML_OK;
 }
 
-static nxml_error_t __nxml_parse_cdata(nxml_t *doc, char **buffer, size_t *size,
-                                       nxml_data_t **data) {
+static nxml_error_t
+__nxml_parse_cdata (nxml_t * doc, char **buffer, size_t * size,
+		    nxml_data_t ** data)
+{
   /*
-   * Rule [18] - CDSect ::= CDStart CData CDEnd
+   * Rule [18] - CDSect ::= CDStart CData CDEnd 
    * Rule [19] - CDStart ::= '<![CDATA['
    * Rule [20] - CData ::= (Char * - (Char * ']]>' Char *))
    * Rule [21] - CDEnd ::= ']]>'
@@ -278,35 +312,38 @@ static nxml_error_t __nxml_parse_cdata(nxml_t *doc, char **buffer, size_t *size,
   nxml_data_t *t;
   char *value;
 
-  while (i < *size) {
-    if (!strncmp(*buffer + i, "]]>", 3))
-      break;
+  while (i < *size)
+    {
+      if (!strncmp (*buffer + i, "]]>", 3))
+	break;
 
-    if (*(*buffer + i) == 0xa && doc->priv.func)
-      doc->priv.line++;
+      if (*(*buffer + i) == 0xa && doc->priv.func)
+	doc->priv.line++;
 
-    i++;
-  }
+      i++;
+    }
 
-  if (strncmp(*buffer + i, "]]>", 3)) {
-    if (doc->priv.func)
-      doc->priv.func("%s: expected ']]>' as close of a CDATA (line %d)\n",
-                     doc->file ? doc->file : "", doc->priv.line);
+  if (strncmp (*buffer + i, "]]>", 3))
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: expected ']]>' as close of a CDATA (line %d)\n",
+			doc->file ? doc->file : "", doc->priv.line);
 
-    return NXML_ERR_PARSER;
-  }
+      return NXML_ERR_PARSER;
+    }
 
-  if (!(t = (nxml_data_t *)calloc(1, sizeof(nxml_data_t))))
+  if (!(t = (nxml_data_t *) calloc (1, sizeof (nxml_data_t))))
     return NXML_ERR_POSIX;
 
   t->doc = doc;
 
-  if (!(value = (char *)malloc(sizeof(char) * (i + 1)))) {
-    free(t);
-    return NXML_ERR_POSIX;
-  }
+  if (!(value = (char *) malloc (sizeof (char) * (i + 1))))
+    {
+      free (t);
+      return NXML_ERR_POSIX;
+    }
 
-  strncpy(value, *buffer, i);
+  strncpy (value, *buffer, i);
   value[i] = 0;
 
   t->value = value;
@@ -320,7 +357,9 @@ static nxml_error_t __nxml_parse_cdata(nxml_t *doc, char **buffer, size_t *size,
   return NXML_OK;
 }
 
-static void __nxml_parse_entity(nxml_t *doc, char **buffer, size_t *size) {
+static void
+__nxml_parse_entity (nxml_t * doc, char **buffer, size_t * size)
+{
   /*
    * [70]       EntityDecl ::=          GEDecl | PEDecl
    * [71]       GEDecl     ::=          '<!ENTITY' S Name S EntityDef S? '>'
@@ -335,137 +374,151 @@ static void __nxml_parse_entity(nxml_t *doc, char **buffer, size_t *size) {
   int byte;
   int64_t ch;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
-  if (strncmp(*buffer, "<!ENTITY", 8)) {
-    int q = i = 0;
+  if (strncmp (*buffer, "<!ENTITY", 8))
+    {
+      int q = i = 0;
 
-    while ((*(*buffer + i) != '>' || q) && i < *size) {
-      if (*(*buffer + i) == '<')
-        q++;
+      while ((*(*buffer + i) != '>' || q) && i < *size)
+	{
+	  if (*(*buffer + i) == '<')
+	    q++;
 
-      else if (*(*buffer + i) == '>')
-        q--;
+	  else if (*(*buffer + i) == '>')
+	    q--;
 
-      i++;
+	  i++;
+	}
+
+      if (*(*buffer) == '>')
+	i++;
+
+      (*buffer) += i;
+      (*size) -= i;
+      return;
     }
-
-    if (*(*buffer) == '>')
-      i++;
-
-    (*buffer) += i;
-    (*size) -= i;
-    return;
-  }
 
   *buffer += 8;
   *size -= 8;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
   /* Name */
-  if (!__NXML_NAMESTARTCHARS) {
-    int q = i = 0;
+  if (!__NXML_NAMESTARTCHARS)
+    {
+      int q = i = 0;
 
-    while ((*(*buffer + i) != '>' || q) && i < *size) {
-      if (*(*buffer + i) == '<')
-        q++;
+      while ((*(*buffer + i) != '>' || q) && i < *size)
+	{
+	  if (*(*buffer + i) == '<')
+	    q++;
 
-      else if (*(*buffer + i) == '>')
-        q--;
+	  else if (*(*buffer + i) == '>')
+	    q--;
 
-      i++;
+	  i++;
+	}
+
+      if (*(*buffer) == '>')
+	i++;
+
+      (*buffer) += i;
+      (*size) -= i;
+      return;
     }
 
-    if (*(*buffer) == '>')
-      i++;
-
-    (*buffer) += i;
-    (*size) -= i;
-    return;
-  }
-
-  memcpy(&name[0], *buffer, byte);
+  memcpy (&name[0], *buffer, byte);
 
   i = byte;
   (*buffer) += byte;
   (*size) -= byte;
 
-  while (__NXML_NAMECHARS && *size && i < sizeof(name) - 1) {
-    memcpy(&name[i], *buffer, byte);
+  while (__NXML_NAMECHARS && *size && i < sizeof (name) - 1)
+    {
+      memcpy (&name[i], *buffer, byte);
 
-    i += byte;
-    (*buffer) += byte;
-    (*size) -= byte;
-  }
+      i += byte;
+      (*buffer) += byte;
+      (*size) -= byte;
+    }
 
   name[i] = 0;
 
-  if (!i || !strcmp(name, "%")) {
-    int q = i = 0;
+  if (!i || !strcmp (name, "%"))
+    {
+      int q = i = 0;
 
-    while ((*(*buffer + i) != '>' || q) && i < *size) {
-      if (*(*buffer + i) == '<')
-        q++;
+      while ((*(*buffer + i) != '>' || q) && i < *size)
+	{
+	  if (*(*buffer + i) == '<')
+	    q++;
 
-      else if (*(*buffer + i) == '>')
-        q--;
+	  else if (*(*buffer + i) == '>')
+	    q--;
 
-      i++;
-    }
+	  i++;
+	}
 
-    if (*(*buffer) == '>')
-      i++;
+      if (*(*buffer) == '>')
+	i++;
 
-    (*buffer) += i;
-    (*size) -= i;
-    return;
-  }
-
-  __nxml_escape_spaces(doc, buffer, size);
-
-  entity = __nxml_get_value(doc, buffer, size);
-
-  __nxml_escape_spaces(doc, buffer, size);
-
-  if (**buffer == '>') {
-    (*buffer)++;
-    (*size)--;
-  }
-
-  if (entity) {
-    __nxml_entity_t *e;
-
-    if (!(e = calloc(1, sizeof(__nxml_entity_t)))) {
-      free(entity);
+      (*buffer) += i;
+      (*size) -= i;
       return;
     }
 
-    if (!(e->name = strdup(name))) {
-      free(e);
-      free(entity);
-      return;
+  __nxml_escape_spaces (doc, buffer, size);
+
+  entity = __nxml_get_value (doc, buffer, size);
+
+  __nxml_escape_spaces (doc, buffer, size);
+
+  if (**buffer == '>')
+    {
+      (*buffer)++;
+      (*size)--;
     }
 
-    e->entity = entity;
+  if (entity)
+    {
+      __nxml_entity_t *e;
 
-    if (!doc->priv.entities)
-      doc->priv.entities = e;
-    else {
-      __nxml_entity_t *tmp = doc->priv.entities;
+      if (!(e = calloc (1, sizeof (__nxml_entity_t))))
+	{
+	  free (entity);
+	  return;
+	}
 
-      while (tmp->next)
-        tmp = tmp->next;
+      if (!(e->name = strdup (name)))
+	{
+	  free (e);
+	  free (entity);
+	  return;
+	}
 
-      tmp->next = e;
+      e->entity = entity;
+
+      if (!doc->priv.entities)
+	doc->priv.entities = e;
+      else
+	{
+	  __nxml_entity_t *tmp = doc->priv.entities;
+
+	  while (tmp->next)
+	    tmp = tmp->next;
+
+	  tmp->next = e;
+	}
     }
-  }
 }
 
-static nxml_error_t __nxml_parse_doctype(nxml_t *doc, char **buffer,
-                                         size_t *size, int *doctype) {
+static nxml_error_t
+__nxml_parse_doctype (nxml_t * doc, char **buffer, size_t * size,
+		      int *doctype)
+{
   /*
-   * Rule [28] - doctypedecl ::= '<!DOCTYPE' S Name (S ExternalID)? S?
+   * Rule [28] - doctypedecl ::= '<!DOCTYPE' S Name (S ExternalID)? S? 
    *                             ('[' intSubset '] S?)? '>'
    */
 
@@ -478,72 +531,78 @@ static nxml_error_t __nxml_parse_doctype(nxml_t *doc, char **buffer,
   int64_t ch;
   int q = 0;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
-  if (!__NXML_NAMESTARTCHARS) {
-    if (doc->priv.func)
-      doc->priv.func("%s: abnormal char '%c' (line %d)\n",
-                     doc->file ? doc->file : "", **buffer, doc->priv.line);
-    return NXML_ERR_PARSER;
-  }
+  if (!__NXML_NAMESTARTCHARS)
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: abnormal char '%c' (line %d)\n",
+			doc->file ? doc->file : "", **buffer, doc->priv.line);
+      return NXML_ERR_PARSER;
+    }
 
-  memcpy(&str[0], *buffer, byte);
+  memcpy (&str[0], *buffer, byte);
 
   i = byte;
   (*buffer) += byte;
   (*size) -= byte;
 
-  while (__NXML_NAMECHARS && *size && i < sizeof(str) - 1) {
-    memcpy(&str[i], *buffer, byte);
+  while (__NXML_NAMECHARS && *size && i < sizeof (str) - 1)
+    {
+      memcpy (&str[i], *buffer, byte);
 
-    i += byte;
-    (*buffer) += byte;
-    (*size) -= byte;
-  }
+      i += byte;
+      (*buffer) += byte;
+      (*size) -= byte;
+    }
 
   str[i] = 0;
 
-  if (!(t = (nxml_doctype_t *)calloc(1, sizeof(nxml_doctype_t))))
+  if (!(t = (nxml_doctype_t *) calloc (1, sizeof (nxml_doctype_t))))
     return NXML_ERR_POSIX;
 
   t->doc = doc;
 
-  if (!(t->name = strdup(str))) {
-    free(t);
-    return NXML_ERR_POSIX;
-  }
+  if (!(t->name = strdup (str)))
+    {
+      free (t);
+      return NXML_ERR_POSIX;
+    }
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
   i = 0;
-  while ((*(*buffer + i) != '>' || q) && i < *size) {
-    if (*(*buffer + i) == '<')
-      q++;
+  while ((*(*buffer + i) != '>' || q) && i < *size)
+    {
+      if (*(*buffer + i) == '<')
+	q++;
 
-    else if (*(*buffer + i) == '>')
-      q--;
+      else if (*(*buffer + i) == '>')
+	q--;
 
-    if (*(*buffer + i) == 0xa && doc->priv.func)
-      doc->priv.line++;
+      if (*(*buffer + i) == 0xa && doc->priv.func)
+	doc->priv.line++;
 
-    i++;
-  }
+      i++;
+    }
 
-  if (*(*buffer + i) != '>') {
-    if (doc->priv.func)
-      doc->priv.func("%s: expected '>' as close of a doctype (line %d)\n",
-                     doc->file ? doc->file : "", doc->priv.line);
+  if (*(*buffer + i) != '>')
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: expected '>' as close of a doctype (line %d)\n",
+			doc->file ? doc->file : "", doc->priv.line);
 
-    free(t->value);
-    free(t);
-    return NXML_ERR_PARSER;
-  }
+      free (t->value);
+      free (t);
+      return NXML_ERR_PARSER;
+    }
 
-  if (!(value = __nxml_parse_string(doc, *buffer, i))) {
-    free(t->value);
-    free(t);
-    return NXML_ERR_POSIX;
-  }
+  if (!(value = __nxml_parse_string (doc, *buffer, i)))
+    {
+      free (t->value);
+      free (t);
+      return NXML_ERR_POSIX;
+    }
 
   t->value = value;
 
@@ -554,34 +613,38 @@ static nxml_error_t __nxml_parse_doctype(nxml_t *doc, char **buffer,
   if (!tmp)
     doc->doctype = t;
 
-  else {
-    while (tmp->next)
-      tmp = tmp->next;
+  else
+    {
+      while (tmp->next)
+	tmp = tmp->next;
 
-    tmp->next = t;
-  }
+      tmp->next = t;
+    }
 
   *doctype = 1;
 
   while (value && *value && *value != '[')
     value++;
 
-  if (value && *value == '[') {
-    unsigned int size;
+  if (value && *value == '[')
+    {
+      unsigned int size;
 
-    value++;
-    size = strlen(value);
+      value++;
+      size = strlen (value);
 
-    while (size > 0 && value && *value)
-      __nxml_parse_entity(doc, &value, (size_t *)&size);
-  }
+      while (size > 0 && value && *value)
+	__nxml_parse_entity (doc, &value, (size_t *) & size);
+    }
 
   return NXML_OK;
 }
 
-static nxml_error_t __nxml_parse_comment(nxml_t *doc, char **buffer,
-                                         size_t *size, nxml_data_t **data) {
-  /*
+static nxml_error_t
+__nxml_parse_comment (nxml_t * doc, char **buffer, size_t * size,
+		      nxml_data_t ** data)
+{
+  /* 
    * Rule [15] - Comment ::= '<!--' ((Char - '-') | ('-' (Char - '-')))* '-->'
    */
 
@@ -589,29 +652,32 @@ static nxml_error_t __nxml_parse_comment(nxml_t *doc, char **buffer,
   nxml_data_t *t;
   char *value;
 
-  while (strncmp(*buffer + i, "-->", 3) && i < *size) {
-    if (*(*buffer + i) == 0xa && doc->priv.func)
-      doc->priv.line++;
-    i++;
-  }
+  while (strncmp (*buffer + i, "-->", 3) && i < *size)
+    {
+      if (*(*buffer + i) == 0xa && doc->priv.func)
+	doc->priv.line++;
+      i++;
+    }
 
-  if (strncmp(*buffer + i, "-->", 3)) {
-    if (doc->priv.func)
-      doc->priv.func("%s: expected '--' as close comment (line %d)\n",
-                     doc->file ? doc->file : "", doc->priv.line);
+  if (strncmp (*buffer + i, "-->", 3))
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: expected '--' as close comment (line %d)\n",
+			doc->file ? doc->file : "", doc->priv.line);
 
-    return NXML_ERR_PARSER;
-  }
+      return NXML_ERR_PARSER;
+    }
 
-  if (!(t = (nxml_data_t *)calloc(1, sizeof(nxml_data_t))))
+  if (!(t = (nxml_data_t *) calloc (1, sizeof (nxml_data_t))))
     return NXML_ERR_POSIX;
 
   t->doc = doc;
 
-  if (!(value = __nxml_parse_string(doc, *buffer, i))) {
-    free(t);
-    return NXML_ERR_POSIX;
-  }
+  if (!(value = __nxml_parse_string (doc, *buffer, i)))
+    {
+      free (t);
+      return NXML_ERR_POSIX;
+    }
 
   t->value = value;
 
@@ -625,10 +691,12 @@ static nxml_error_t __nxml_parse_comment(nxml_t *doc, char **buffer,
   return NXML_OK;
 }
 
-static nxml_error_t __nxml_parse_pi(nxml_t *doc, char **buffer, size_t *size,
-                                    nxml_data_t **data) {
-  /*
-   * Rule [16] - PI ::= '<?' PITarget (S (Char * - (Char * '?>' Char *)))?
+static nxml_error_t
+__nxml_parse_pi (nxml_t * doc, char **buffer, size_t * size,
+		 nxml_data_t ** data)
+{
+  /* 
+   * Rule [16] - PI ::= '<?' PITarget (S (Char * - (Char * '?>' Char *)))? 
    *                    '?>'
    * Rule [17] - PITarget ::= Name - (('X' | 'x') ('M' | 'm') ('L' | 'l'))
    */
@@ -645,37 +713,41 @@ static nxml_error_t __nxml_parse_pi(nxml_t *doc, char **buffer, size_t *size,
   (*buffer) += 1;
   (*size) -= 1;
 
-  while (strncmp(*buffer + i, "?>", 2) && i < *size) {
-    if (*(*buffer + i) == 0xa && doc->priv.func)
-      doc->priv.line++;
-    i++;
-  }
+  while (strncmp (*buffer + i, "?>", 2) && i < *size)
+    {
+      if (*(*buffer + i) == 0xa && doc->priv.func)
+	doc->priv.line++;
+      i++;
+    }
 
-  if (strncmp(*buffer + i, "?>", 2)) {
-    if (doc->priv.func)
-      doc->priv.func("%s: expected '?' as close pi tag (line %d)\n",
-                     doc->file ? doc->file : "", doc->priv.line);
+  if (strncmp (*buffer + i, "?>", 2))
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: expected '?' as close pi tag (line %d)\n",
+			doc->file ? doc->file : "", doc->priv.line);
 
-    return NXML_ERR_PARSER;
-  }
+      return NXML_ERR_PARSER;
+    }
 
-  if (!strncasecmp(*buffer, "?xml", 4)) {
-    if (doc->priv.func)
-      doc->priv.func("%s: pi xml is reserved! (line %d)\n",
-                     doc->file ? doc->file : "", doc->priv.line);
+  if (!strncasecmp (*buffer, "?xml", 4))
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: pi xml is reserved! (line %d)\n",
+			doc->file ? doc->file : "", doc->priv.line);
 
-    return NXML_ERR_PARSER;
-  }
+      return NXML_ERR_PARSER;
+    }
 
-  if (!(t = (nxml_data_t *)calloc(1, sizeof(nxml_data_t))))
+  if (!(t = (nxml_data_t *) calloc (1, sizeof (nxml_data_t))))
     return NXML_ERR_POSIX;
 
   t->doc = doc;
 
-  if (!(value = __nxml_parse_string(doc, *buffer, i))) {
-    free(t);
-    return NXML_ERR_POSIX;
-  }
+  if (!(value = __nxml_parse_string (doc, *buffer, i)))
+    {
+      free (t);
+      return NXML_ERR_POSIX;
+    }
 
   t->value = value;
 
@@ -689,8 +761,10 @@ static nxml_error_t __nxml_parse_pi(nxml_t *doc, char **buffer, size_t *size,
   return NXML_OK;
 }
 
-static nxml_error_t __nxml_parse_other(nxml_t *doc, char **buffer, size_t *size,
-                                       nxml_data_t **data, int *doctype) {
+static nxml_error_t
+__nxml_parse_other (nxml_t * doc, char **buffer, size_t * size,
+		    nxml_data_t ** data, int *doctype)
+{
   /* Tags '<!'... */
 
   *data = NULL;
@@ -702,40 +776,46 @@ static nxml_error_t __nxml_parse_other(nxml_t *doc, char **buffer, size_t *size,
   (*buffer) += 1;
   (*size) -= 1;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
-  if (!strncmp(*buffer, "[CDATA[", 7)) {
-    (*buffer) += 7;
-    (*size) -= 7;
+  if (!strncmp (*buffer, "[CDATA[", 7))
+    {
+      (*buffer) += 7;
+      (*size) -= 7;
 
-    return __nxml_parse_cdata(doc, buffer, size, data);
-  }
+      return __nxml_parse_cdata (doc, buffer, size, data);
+    }
 
-  else if (!strncmp(*buffer, "--", 2)) {
-    (*buffer) += 2;
-    (*size) -= 2;
+  else if (!strncmp (*buffer, "--", 2))
+    {
+      (*buffer) += 2;
+      (*size) -= 2;
 
-    return __nxml_parse_comment(doc, buffer, size, data);
-  }
+      return __nxml_parse_comment (doc, buffer, size, data);
+    }
 
-  else if (!strncmp(*buffer, "DOCTYPE", 7)) {
-    (*buffer) += 7;
-    (*size) -= 7;
+  else if (!strncmp (*buffer, "DOCTYPE", 7))
+    {
+      (*buffer) += 7;
+      (*size) -= 7;
 
-    return __nxml_parse_doctype(doc, buffer, size, doctype);
-  }
+      return __nxml_parse_doctype (doc, buffer, size, doctype);
+    }
 
-  else {
-    if (doc->priv.func)
-      doc->priv.func("%s: abnormal tag (line %d)\n", doc->file ? doc->file : "",
-                     doc->priv.line);
+  else
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: abnormal tag (line %d)\n",
+			doc->file ? doc->file : "", doc->priv.line);
 
-    return NXML_ERR_PARSER;
-  }
+      return NXML_ERR_PARSER;
+    }
 }
 
-static nxml_error_t __nxml_parse_text(nxml_t *doc, char **buffer, size_t *size,
-                                      nxml_data_t **data) {
+static nxml_error_t
+__nxml_parse_text (nxml_t * doc, char **buffer, size_t * size,
+		   nxml_data_t ** data)
+{
   int i = 0;
   nxml_data_t *t;
   char *value;
@@ -746,32 +826,35 @@ static nxml_error_t __nxml_parse_text(nxml_t *doc, char **buffer, size_t *size,
   if (!*size)
     return NXML_OK;
 
-  while (*(*buffer + i) != '<' && i < *size) {
-    if (*(*buffer + i) == 0xa && doc->priv.func)
-      doc->priv.line++;
-    i++;
-  }
+  while (*(*buffer + i) != '<' && i < *size)
+    {
+      if (*(*buffer + i) == 0xa && doc->priv.func)
+	doc->priv.line++;
+      i++;
+    }
 
-  if (!(t = (nxml_data_t *)calloc(1, sizeof(nxml_data_t))))
+  if (!(t = (nxml_data_t *) calloc (1, sizeof (nxml_data_t))))
     return NXML_ERR_POSIX;
 
   t->doc = doc;
 
-  if (!(value = __nxml_parse_string(doc, *buffer, i))) {
-    free(t);
-    return NXML_ERR_POSIX;
-  }
+  if (!(value = __nxml_parse_string (doc, *buffer, i)))
+    {
+      free (t);
+      return NXML_ERR_POSIX;
+    }
 
   (*buffer) += i;
   (*size) -= i;
 
-  value_new = __nxml_trim(value);
-  free(value);
+  value_new = __nxml_trim (value);
+  free (value);
 
-  if (!value_new) {
-    free(t);
-    return NXML_ERR_POSIX;
-  }
+  if (!value_new)
+    {
+      free (t);
+      return NXML_ERR_POSIX;
+    }
 
   t->value = value_new;
   t->type = NXML_TYPE_TEXT;
@@ -781,9 +864,11 @@ static nxml_error_t __nxml_parse_text(nxml_t *doc, char **buffer, size_t *size,
   return NXML_OK;
 }
 
-static nxml_error_t __nxml_parse_close(nxml_t *doc, char **buffer, size_t *size,
-                                       nxml_data_t **data) {
-  /*
+static nxml_error_t
+__nxml_parse_close (nxml_t * doc, char **buffer, size_t * size,
+		    nxml_data_t ** data)
+{
+  /* 
    * Rule [42] - ETag ::= '</' Name S? '>'
    */
 
@@ -798,50 +883,54 @@ static nxml_error_t __nxml_parse_close(nxml_t *doc, char **buffer, size_t *size,
   if (!*size)
     return NXML_OK;
 
-  if (!__NXML_NAMESTARTCHARS) {
-    if (doc->priv.func)
-      doc->priv.func("%s: abnormal char '%c' (line %d)\n",
-                     doc->file ? doc->file : "", **buffer, doc->priv.line);
-    return NXML_ERR_PARSER;
-  }
+  if (!__NXML_NAMESTARTCHARS)
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: abnormal char '%c' (line %d)\n",
+			doc->file ? doc->file : "", **buffer, doc->priv.line);
+      return NXML_ERR_PARSER;
+    }
 
-  memcpy(&str[0], *buffer, byte);
+  memcpy (&str[0], *buffer, byte);
 
   i = byte;
   (*buffer) += byte;
   (*size) -= byte;
 
-  while (__NXML_NAMECHARS && *size && i < sizeof(str) - 1) {
-    memcpy(&str[i], *buffer, byte);
+  while (__NXML_NAMECHARS && *size && i < sizeof (str) - 1)
+    {
+      memcpy (&str[i], *buffer, byte);
 
-    i += byte;
-    (*buffer) += byte;
-    (*size) -= byte;
-  }
+      i += byte;
+      (*buffer) += byte;
+      (*size) -= byte;
+    }
 
   str[i] = 0;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
-  if (**buffer != '>') {
-    if (doc->priv.func)
-      doc->priv.func("%s: expected char '>' after tag %s (line %d)\n",
-                     doc->file ? doc->file : "", str, doc->priv.line);
-    return NXML_ERR_PARSER;
-  }
+  if (**buffer != '>')
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: expected char '>' after tag %s (line %d)\n",
+			doc->file ? doc->file : "", str, doc->priv.line);
+      return NXML_ERR_PARSER;
+    }
 
   (*buffer) += 1;
   (*size) -= 1;
 
-  if (!(tag = (nxml_data_t *)calloc(1, sizeof(nxml_data_t))))
+  if (!(tag = (nxml_data_t *) calloc (1, sizeof (nxml_data_t))))
     return NXML_ERR_POSIX;
 
   tag->doc = doc;
 
-  if (!(tag->value = strdup(str))) {
-    free(tag);
-    return NXML_ERR_POSIX;
-  }
+  if (!(tag->value = strdup (str)))
+    {
+      free (tag);
+      return NXML_ERR_POSIX;
+    }
 
   tag->type = NXML_TYPE_ELEMENT_CLOSE;
 
@@ -850,9 +939,10 @@ static nxml_error_t __nxml_parse_close(nxml_t *doc, char **buffer, size_t *size,
   return NXML_OK;
 }
 
-static nxml_error_t __nxml_parse_get_tag(nxml_t *doc, char **buffer,
-                                         size_t *size, nxml_data_t **data,
-                                         int *doctype) {
+static nxml_error_t
+__nxml_parse_get_tag (nxml_t * doc, char **buffer, size_t * size,
+		      nxml_data_t ** data, int *doctype)
+{
   /* Parse the element... */
   nxml_attr_t *attr, *last;
   nxml_data_t *tag, *child, *child_last;
@@ -870,197 +960,220 @@ static nxml_error_t __nxml_parse_get_tag(nxml_t *doc, char **buffer,
   if (!*size)
     return NXML_OK;
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
   /* Text */
   if (**buffer != '<')
-    return __nxml_parse_text(doc, buffer, size, data);
+    return __nxml_parse_text (doc, buffer, size, data);
 
   (*buffer) += 1;
   (*size) -= 1;
 
   /* Comment, CData, DocType or other elements */
   if (**buffer == '!')
-    return __nxml_parse_other(doc, buffer, size, data, doctype);
+    return __nxml_parse_other (doc, buffer, size, data, doctype);
 
   /* PI */
   else if (**buffer == '?')
-    return __nxml_parse_pi(doc, buffer, size, data);
+    return __nxml_parse_pi (doc, buffer, size, data);
 
   /* Close tag */
-  else if (**buffer == '/') {
-    (*buffer) += 1;
-    (*size) -= 1;
-    return __nxml_parse_close(doc, buffer, size, data);
-  }
+  else if (**buffer == '/')
+    {
+      (*buffer) += 1;
+      (*size) -= 1;
+      return __nxml_parse_close (doc, buffer, size, data);
+    }
 
-  __nxml_escape_spaces(doc, buffer, size);
+  __nxml_escape_spaces (doc, buffer, size);
 
-  if (!__NXML_NAMESTARTCHARS) {
-    if (doc->priv.func)
-      doc->priv.func("%s: abnormal char '%c' (line %d)\n",
-                     doc->file ? doc->file : "", **buffer, doc->priv.line);
-    return NXML_ERR_PARSER;
-  }
+  if (!__NXML_NAMESTARTCHARS)
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: abnormal char '%c' (line %d)\n",
+			doc->file ? doc->file : "", **buffer, doc->priv.line);
+      return NXML_ERR_PARSER;
+    }
 
-  memcpy(&str[0], *buffer, byte);
+  memcpy (&str[0], *buffer, byte);
 
   i = byte;
   (*buffer) += byte;
   (*size) -= byte;
 
-  while (__NXML_NAMECHARS && *size && i < sizeof(str) - 1) {
-    memcpy(&str[i], *buffer, byte);
+  while (__NXML_NAMECHARS && *size && i < sizeof (str) - 1)
+    {
+      memcpy (&str[i], *buffer, byte);
 
-    i += byte;
-    (*buffer) += byte;
-    (*size) -= byte;
-  }
+      i += byte;
+      (*buffer) += byte;
+      (*size) -= byte;
+    }
 
   str[i] = 0;
 
-  if (**buffer != 0x20 && **buffer != 0x9 && **buffer != 0xa &&
-      **buffer != 0xd && **buffer != '>' && **buffer != '/') {
-    (*buffer) -= i;
-    (*size) += i;
+  if (**buffer != 0x20 && **buffer != 0x9 && **buffer != 0xa
+      && **buffer != 0xd && **buffer != '>' && **buffer != '/')
+    {
+      (*buffer) -= i;
+      (*size) += i;
 
-    if (doc->priv.func)
-      doc->priv.func("%s: abnormal char '%c' after tag %s (line %d)\n",
-                     doc->file ? doc->file : "", *(*buffer + i), str,
-                     doc->priv.line);
+      if (doc->priv.func)
+	doc->priv.func ("%s: abnormal char '%c' after tag %s (line %d)\n",
+			doc->file ? doc->file : "", *(*buffer + i), str,
+			doc->priv.line);
 
-    return NXML_ERR_PARSER;
-  }
+      return NXML_ERR_PARSER;
+    }
 
-  if (!(tag = (nxml_data_t *)calloc(1, sizeof(nxml_data_t))))
+  if (!(tag = (nxml_data_t *) calloc (1, sizeof (nxml_data_t))))
     return NXML_ERR_POSIX;
 
   tag->doc = doc;
 
-  if (!(tag->value = strdup(str))) {
-    free(tag);
-    return NXML_ERR_POSIX;
-  }
+  if (!(tag->value = strdup (str)))
+    {
+      free (tag);
+      return NXML_ERR_POSIX;
+    }
 
   last = NULL;
 
   /* Get attribute: */
-  while (!(err = __nxml_parse_get_attribute(doc, buffer, size, &attr)) &&
-         attr) {
-    if (!*size)
-      return NXML_ERR_PARSER;
+  while (!(err = __nxml_parse_get_attribute (doc, buffer, size, &attr))
+	 && attr)
+    {
+      if (!*size)
+	return NXML_ERR_PARSER;
 
-    if (__nxml_parse_unique_attribute(tag->attributes, attr->name)) {
-      if (doc->priv.func)
-        doc->priv.func("%s: Duplicate attribute '%s' in tag '%s' (line %d)\n",
-                       doc->file ? doc->file : "", attr->name, tag->value,
-                       doc->priv.line);
+      if (__nxml_parse_unique_attribute (tag->attributes, attr->name))
+	{
+	  if (doc->priv.func)
+	    doc->priv.
+	      func ("%s: Duplicate attribute '%s' in tag '%s' (line %d)\n",
+		    doc->file ? doc->file : "", attr->name, tag->value,
+		    doc->priv.line);
 
-      nxml_free_attribute(attr);
-      nxml_free_data(tag);
+	  nxml_free_attribute (attr);
+	  nxml_free_data (tag);
 
-      return NXML_ERR_PARSER;
+	  return NXML_ERR_PARSER;
+	}
+
+      if (last)
+	last->next = attr;
+      else
+	tag->attributes = attr;
+
+      last = attr;
     }
 
-    if (last)
-      last->next = attr;
-    else
-      tag->attributes = attr;
-
-    last = attr;
-  }
-
-  if (err) {
-    nxml_free_data(tag);
-    return err;
-  }
+  if (err)
+    {
+      nxml_free_data (tag);
+      return err;
+    }
 
   /* Closed element */
-  if (**buffer == '/') {
-    closed++;
-    (*buffer) += 1;
-    (*size) -= 1;
+  if (**buffer == '/')
+    {
+      closed++;
+      (*buffer) += 1;
+      (*size) -= 1;
 
-    __nxml_escape_spaces(doc, buffer, size);
-  }
+      __nxml_escape_spaces (doc, buffer, size);
+    }
 
-  if (**buffer != '>') {
-    if (doc->priv.func)
-      doc->priv.func("%s: expected char '>' after tag %s (line %d)\n",
-                     doc->file ? doc->file : "", tag->value, doc->priv.line);
+  if (**buffer != '>')
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: expected char '>' after tag %s (line %d)\n",
+			doc->file ? doc->file : "", tag->value,
+			doc->priv.line);
 
-    nxml_free_data(tag);
-    return NXML_ERR_PARSER;
-  }
+      nxml_free_data (tag);
+      return NXML_ERR_PARSER;
+    }
 
   (*buffer) += 1;
   (*size) -= 1;
 
-  if (!closed) {
-    child_last = NULL;
+  if (!closed)
+    {
+      child_last = NULL;
 
-    /* Search children: */
-    while (!(err = __nxml_parse_get_tag(doc, buffer, size, &child, doctype)) &&
-           (*doctype || child)) {
-      if (*doctype)
-        continue;
+      /* Search children: */
+      while (!
+	     (err = __nxml_parse_get_tag (doc, buffer, size, &child, doctype))
+	     && (*doctype || child))
+	{
+	  if (*doctype)
+	    continue;
 
-      /* If the current child, break: */
-      if (child->type == NXML_TYPE_ELEMENT_CLOSE) {
-        if (!strcmp(child->value, tag->value)) {
-          closed = 1;
-          nxml_free_data(child);
-          break;
-        }
+	  /* If the current child, break: */
+	  if (child->type == NXML_TYPE_ELEMENT_CLOSE)
+	    {
+	      if (!strcmp (child->value, tag->value))
+		{
+		  closed = 1;
+		  nxml_free_data (child);
+		  break;
+		}
 
-        else {
-          if (doc->priv.func)
-            doc->priv.func("%s: expected tag '/%s' and not '%s' (line %d)\n",
-                           doc->file ? doc->file : "", tag->value, child->value,
-                           doc->priv.line);
+	      else
+		{
+		  if (doc->priv.func)
+		    doc->priv.
+		      func ("%s: expected tag '/%s' and not '%s' (line %d)\n",
+			    doc->file ? doc->file : "", tag->value,
+			    child->value, doc->priv.line);
 
-          nxml_free_data(child);
-          nxml_free_data(tag);
+		  nxml_free_data (child);
+		  nxml_free_data (tag);
 
-          return NXML_ERR_PARSER;
-        }
-      }
+		  return NXML_ERR_PARSER;
+		}
+	    }
 
-      /* Set the parent */
-      child->parent = tag;
+	  /* Set the parent */
+	  child->parent = tag;
 
-      if (child_last)
-        child_last->next = child;
-      else
-        tag->children = child;
+	  if (child_last)
+	    child_last->next = child;
+	  else
+	    tag->children = child;
 
-      child_last = child;
+	  child_last = child;
+	}
+
+      if (err)
+	{
+	  nxml_free_data (tag);
+	  return err;
+	}
     }
-
-    if (err) {
-      nxml_free_data(tag);
-      return err;
-    }
-  }
 
   tag->type = NXML_TYPE_ELEMENT;
 
-  if (!closed) {
-    if (doc->priv.func)
-      doc->priv.func("%s: expected tag '/%s' (line %d)\n",
-                     doc->file ? doc->file : "", tag->value, doc->priv.line);
+  if (!closed)
+    {
+      if (doc->priv.func)
+	doc->priv.func ("%s: expected tag '/%s' (line %d)\n",
+			doc->file ? doc->file : "", tag->value,
+			doc->priv.line);
 
-    nxml_free_data(tag);
-    return NXML_ERR_PARSER;
-  }
+      nxml_free_data (tag);
+      return NXML_ERR_PARSER;
+    }
 
   *data = tag;
   return NXML_OK;
 }
 
-static nxml_error_t __nxml_parse_buffer(nxml_t *nxml, char *r_buffer,
-                                        size_t r_size) {
-  /*
+static nxml_error_t
+__nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
+{
+  /* 
    * Rule [1] - Document ::= prolog element Misc* - Char* RestrictedChar Char*
    */
 
@@ -1079,184 +1192,202 @@ static nxml_error_t __nxml_parse_buffer(nxml_t *nxml, char *r_buffer,
     return NXML_ERR_DATA;
 
   if (!r_size)
-    r_size = strlen(r_buffer);
+    r_size = strlen (r_buffer);
 
-  switch ((freed = __nxml_utf_detection(r_buffer, r_size, &buffer, &size,
-                                        &charset))) {
-  case 0:
-    buffer = r_buffer;
-    size = r_size;
-    break;
+  switch ((freed =
+	   __nxml_utf_detection (r_buffer, r_size, &buffer, &size, &charset)))
+    {
+    case 0:
+      buffer = r_buffer;
+      size = r_size;
+      break;
 
-  case -1:
-    return NXML_ERR_POSIX;
-  }
+    case -1:
+      return NXML_ERR_POSIX;
+    }
 
   nxml->priv.line = 1;
   nxml->version = NXML_VERSION_1_0;
   nxml->standalone = 1;
 
-  /*
+  /* 
    * Rule [22] - prolog ::= XMLDecl Misc* (doctypedecl Misc*)?
    * Rule [23] - XMLDecl ::= '<?xml' VersionInfo EncodingDecl? SDDecl? S? '?>'
    */
-  if (!strncmp(buffer, "<?xml ", 6)) {
-    buffer += 6;
-    size -= 6;
+  if (!strncmp (buffer, "<?xml ", 6))
+    {
+      buffer += 6;
+      size -= 6;
 
-    if ((err = __nxml_parse_get_attribute(nxml, &buffer, &size, &attr)) !=
-        NXML_OK) {
-      nxml_empty(nxml);
+      if ((err =
+	   __nxml_parse_get_attribute (nxml, &buffer, &size,
+				       &attr)) != NXML_OK)
+	{
+	  nxml_empty (nxml);
 
-      if (freed)
-        free(buffer);
+	  if (freed)
+	    free (buffer);
 
-      return err;
+	  return err;
+	}
+
+      if (!attr)
+	{
+	  if (nxml->priv.func)
+	    nxml->priv.func ("%s: expected 'version' attribute (line %d)\n",
+			     nxml->file ? nxml->file : "", nxml->priv.line);
+
+	  if (freed)
+	    free (buffer);
+
+	  return NXML_ERR_PARSER;
+	}
+
+      if (!strcmp (attr->value, "1.0"))
+	nxml->version = NXML_VERSION_1_0;
+
+      else if (!strcmp (attr->value, "1.1"))
+	nxml->version = NXML_VERSION_1_1;
+
+      else
+	{
+	  if (nxml->priv.func)
+	    nxml->priv.
+	      func (PACKAGE " " VERSION
+		    " supports only xml 1.1 or 1.0 (line %d)\n",
+		    nxml->priv.line);
+
+	  if (freed)
+	    free (buffer);
+
+	  return NXML_ERR_PARSER;
+	}
+
+      nxml_free_attribute (attr);
+
+      while (!(err = __nxml_parse_get_attribute (nxml, &buffer, &size, &attr))
+	     && attr)
+	{
+	  if (!strcmp (attr->name, "standalone"))
+	    {
+	      if (!strcmp (attr->value, "yes"))
+		nxml->standalone = 1;
+
+	      else
+		nxml->standalone = 0;
+	    }
+
+	  else if (!strcmp (attr->name, "encoding"))
+	    {
+	      nxml->encoding = strdup (attr->value);
+
+	      if (!nxml->encoding)
+		{
+		  nxml_empty (nxml);
+		  nxml_free_attribute (attr);
+
+		  if (freed)
+		    free (buffer);
+
+		  return NXML_ERR_POSIX;
+		}
+	    }
+
+	  else
+	    {
+
+	      if (nxml->priv.func)
+		nxml->priv.func ("%s: unexpected attribute '%s' (line %d)\n",
+				 nxml->file ? nxml->file : "", attr->name,
+				 nxml->priv.line);
+
+	      nxml_empty (nxml);
+	      nxml_free_attribute (attr);
+
+	      if (freed)
+		free (buffer);
+
+	      return NXML_ERR_PARSER;
+	    }
+
+	  nxml_free_attribute (attr);
+	}
+
+      if (err || strncmp (buffer, "?>", 2))
+	{
+	  if (nxml->priv.func)
+	    nxml->priv.func ("%s expected '?>' (line %d)\n",
+			     nxml->file ? nxml->file : "", nxml->priv.line);
+
+	  nxml_empty (nxml);
+
+	  if (freed)
+	    free (buffer);
+
+	  return NXML_ERR_PARSER;
+	}
+
+      buffer += 2;
+      size -= 2;
     }
-
-    if (!attr) {
-      if (nxml->priv.func)
-        nxml->priv.func("%s: expected 'version' attribute (line %d)\n",
-                        nxml->file ? nxml->file : "", nxml->priv.line);
-
-      if (freed)
-        free(buffer);
-
-      return NXML_ERR_PARSER;
-    }
-
-    if (!strcmp(attr->value, "1.0"))
-      nxml->version = NXML_VERSION_1_0;
-
-    else if (!strcmp(attr->value, "1.1"))
-      nxml->version = NXML_VERSION_1_1;
-
-    else {
-      if (nxml->priv.func)
-        nxml->priv.func(PACKAGE " " VERSION
-                                " supports only xml 1.1 or 1.0 (line %d)\n",
-                        nxml->priv.line);
-
-      if (freed)
-        free(buffer);
-
-      return NXML_ERR_PARSER;
-    }
-
-    nxml_free_attribute(attr);
-
-    while (!(err = __nxml_parse_get_attribute(nxml, &buffer, &size, &attr)) &&
-           attr) {
-      if (!strcmp(attr->name, "standalone")) {
-        if (!strcmp(attr->value, "yes"))
-          nxml->standalone = 1;
-
-        else
-          nxml->standalone = 0;
-      }
-
-      else if (!strcmp(attr->name, "encoding")) {
-        nxml->encoding = strdup(attr->value);
-
-        if (!nxml->encoding) {
-          nxml_empty(nxml);
-          nxml_free_attribute(attr);
-
-          if (freed)
-            free(buffer);
-
-          return NXML_ERR_POSIX;
-        }
-      }
-
-      else {
-
-        if (nxml->priv.func)
-          nxml->priv.func("%s: unexpected attribute '%s' (line %d)\n",
-                          nxml->file ? nxml->file : "", attr->name,
-                          nxml->priv.line);
-
-        nxml_empty(nxml);
-        nxml_free_attribute(attr);
-
-        if (freed)
-          free(buffer);
-
-        return NXML_ERR_PARSER;
-      }
-
-      nxml_free_attribute(attr);
-    }
-
-    if (err || strncmp(buffer, "?>", 2)) {
-      if (nxml->priv.func)
-        nxml->priv.func("%s expected '?>' (line %d)\n",
-                        nxml->file ? nxml->file : "", nxml->priv.line);
-
-      nxml_empty(nxml);
-
-      if (freed)
-        free(buffer);
-
-      return NXML_ERR_PARSER;
-    }
-
-    buffer += 2;
-    size -= 2;
-  }
 
   root = last = NULL;
-  while (!(err = __nxml_parse_get_tag(nxml, &buffer, &size, &tag, &doctype)) &&
-         (doctype || tag)) {
-    if (doctype)
-      continue;
+  while (!(err = __nxml_parse_get_tag (nxml, &buffer, &size, &tag, &doctype))
+	 && (doctype || tag))
+    {
+      if (doctype)
+	continue;
 
-    if (tag->type == NXML_TYPE_ELEMENT && !root)
-      root = tag;
+      if (tag->type == NXML_TYPE_ELEMENT && !root)
+	root = tag;
 
-    if (last)
-      last->next = tag;
-    else
-      nxml->data = tag;
+      if (last)
+	last->next = tag;
+      else
+	nxml->data = tag;
 
-    last = tag;
-  }
+      last = tag;
+    }
 
-  if (err) {
-    nxml_empty(nxml);
+  if (err)
+    {
+      nxml_empty (nxml);
 
-    if (freed)
-      free(buffer);
+      if (freed)
+	free (buffer);
 
-    return NXML_ERR_PARSER;
-  }
+      return NXML_ERR_PARSER;
+    }
 
-  if (!root) {
-    if (nxml->priv.func)
-      nxml->priv.func("%s: No root element founded!\n",
-                      nxml->file ? nxml->file : "");
+  if (!root)
+    {
+      if (nxml->priv.func)
+	nxml->priv.func ("%s: No root element founded!\n",
+			 nxml->file ? nxml->file : "");
 
-    nxml_empty(nxml);
+      nxml_empty (nxml);
 
-    if (freed)
-      free(buffer);
+      if (freed)
+	free (buffer);
 
-    return NXML_ERR_PARSER;
-  }
+      return NXML_ERR_PARSER;
+    }
 
   if (freed)
-    free(buffer);
+    free (buffer);
 
   nxml->charset_detected = charset;
 
-  __nxml_namespace_parse(nxml);
+  __nxml_namespace_parse (nxml);
 
   return NXML_OK;
 }
 
 /* EXTERNAL FUNCTIONS *******************************************************/
 
-nxml_error_t nxml_parse_url(nxml_t *nxml, char *url) {
+nxml_error_t
+nxml_parse_url (nxml_t * nxml, char *url)
+{
   nxml_error_t err;
   char *buffer;
   size_t size;
@@ -1264,29 +1395,32 @@ nxml_error_t nxml_parse_url(nxml_t *nxml, char *url) {
   if (!url || !nxml)
     return NXML_ERR_DATA;
 
-  if ((err = nxml_download_file(nxml, url, &buffer, &size)) != NXML_OK)
+  if ((err = nxml_download_file (nxml, url, &buffer, &size)) != NXML_OK)
     return err;
 
   if (nxml->file)
-    free(nxml->file);
+    free (nxml->file);
 
-  if (!(nxml->file = strdup(url))) {
-    nxml_empty(nxml);
-    return NXML_ERR_POSIX;
-  }
+  if (!(nxml->file = strdup (url)))
+    {
+      nxml_empty (nxml);
+      return NXML_ERR_POSIX;
+    }
 
   nxml->size = size;
 
-  nxml_empty(nxml);
+  nxml_empty (nxml);
 
-  err = __nxml_parse_buffer(nxml, buffer, size);
+  err = __nxml_parse_buffer (nxml, buffer, size);
 
-  free(buffer);
+  free (buffer);
 
   return err;
 }
 
-nxml_error_t nxml_parse_file(nxml_t *nxml, char *file) {
+nxml_error_t
+nxml_parse_file (nxml_t * nxml, char *file)
+{
   nxml_error_t err;
   char *buffer;
   struct stat st;
@@ -1295,66 +1429,72 @@ nxml_error_t nxml_parse_file(nxml_t *nxml, char *file) {
   if (!file || !nxml)
     return NXML_ERR_DATA;
 
-  if (stat(file, &st))
+  if (stat (file, &st))
     return NXML_ERR_POSIX;
 
-  if ((fd = open(file, O_RDONLY)) < 0)
+  if ((fd = open (file, O_RDONLY)) < 0)
     return NXML_ERR_POSIX;
 
-  if (!(buffer = (char *)malloc(sizeof(char) * (st.st_size + 1))))
+  if (!(buffer = (char *) malloc (sizeof (char) * (st.st_size + 1))))
     return NXML_ERR_POSIX;
 
   len = 0;
 
-  while (len < st.st_size) {
-    if ((ret = read(fd, buffer + len, st.st_size - len)) <= 0) {
-      free(buffer);
-      close(fd);
+  while (len < st.st_size)
+    {
+      if ((ret = read (fd, buffer + len, st.st_size - len)) <= 0)
+	{
+	  free (buffer);
+	  close (fd);
+	  return NXML_ERR_POSIX;
+	}
+
+      len += ret;
+    }
+
+  buffer[len] = 0;
+  close (fd);
+
+  nxml_empty (nxml);
+
+  if (nxml->file)
+    free (nxml->file);
+
+  if (!(nxml->file = strdup (file)))
+    {
+      nxml_empty (nxml);
+      free (buffer);
       return NXML_ERR_POSIX;
     }
 
-    len += ret;
-  }
-
-  buffer[len] = 0;
-  close(fd);
-
-  nxml_empty(nxml);
-
-  if (nxml->file)
-    free(nxml->file);
-
-  if (!(nxml->file = strdup(file))) {
-    nxml_empty(nxml);
-    free(buffer);
-    return NXML_ERR_POSIX;
-  }
-
   nxml->size = st.st_size;
 
-  err = __nxml_parse_buffer(nxml, buffer, st.st_size);
+  err = __nxml_parse_buffer (nxml, buffer, st.st_size);
 
-  free(buffer);
+  free (buffer);
   return err;
 }
 
-nxml_error_t nxml_parse_buffer(nxml_t *nxml, char *buffer, size_t size) {
+nxml_error_t
+nxml_parse_buffer (nxml_t * nxml, char *buffer, size_t size)
+{
   if (!buffer || !nxml)
     return NXML_ERR_DATA;
 
-  nxml_empty(nxml);
+  nxml_empty (nxml);
 
   if (nxml->file)
-    free(nxml->file);
+    free (nxml->file);
 
-  if (!(nxml->file = strdup("buffer"))) {
-    nxml_empty(nxml);
-    return NXML_ERR_POSIX;
-  }
+  if (!(nxml->file = strdup ("buffer")))
+    {
+      nxml_empty (nxml);
+      return NXML_ERR_POSIX;
+    }
 
   nxml->size = size;
 
-  return __nxml_parse_buffer(nxml, buffer, size);
+  return __nxml_parse_buffer (nxml, buffer, size);
 }
 
 /* EOF */

--- a/src/nxml_parser.c
+++ b/src/nxml_parser.c
@@ -271,10 +271,10 @@ __nxml_parse_get_attribute (nxml_t *doc,
    */
   char *tag = NULL, *value, *v;
 
+  *attr = NULL;
+
   if (!*size)
     return NXML_OK;
-
-  *attr = NULL;
 
   __nxml_escape_spaces (doc, buffer, size);
 

--- a/src/nxml_parser.c
+++ b/src/nxml_parser.c
@@ -1260,6 +1260,7 @@ __nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
 	  if (freed)
 	    free (buffer);
 
+	  nxml_free_attribute (attr);
 	  return NXML_ERR_PARSER;
 	}
 

--- a/src/nxml_parser.c
+++ b/src/nxml_parser.c
@@ -1171,9 +1171,9 @@ __nxml_parse_get_tag (nxml_t * doc, char **buffer, size_t * size,
 }
 
 static nxml_error_t
-__nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
+__nxml_parse_buffer (nxml_t *nxml, char *r_buffer, size_t r_size)
 {
-  /* 
+  /*
    * Rule [1] - Document ::= prolog element Misc* - Char* RestrictedChar Char*
    */
 
@@ -1207,8 +1207,8 @@ __nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
    * assigned to the allocated buffer and its size, respectively.  We are
    * responsible of freeing the buffer.
    */
-  switch ((freed =
-	   __nxml_utf_detection (r_buffer, r_size, &buffer, &size, &charset)))
+  switch ((freed = __nxml_utf_detection (r_buffer, r_size, &buffer, &size,
+                                         &charset)))
     {
     case 0:
       buffer = r_buffer;
@@ -1223,7 +1223,7 @@ __nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
   nxml->version = NXML_VERSION_1_0;
   nxml->standalone = 1;
 
-  /* 
+  /*
    * Rule [22] - prolog ::= XMLDecl Misc* (doctypedecl Misc*)?
    * Rule [23] - XMLDecl ::= '<?xml' VersionInfo EncodingDecl? SDDecl? S? '?>'
    */
@@ -1232,114 +1232,113 @@ __nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
       buffer += 6;
       size -= 6;
 
-      if ((err =
-	   __nxml_parse_get_attribute (nxml, &buffer, &size,
-				       &attr)) != NXML_OK)
-	{
-	  nxml_empty (nxml);
+      if ((err = __nxml_parse_get_attribute (nxml, &buffer, &size, &attr))
+          != NXML_OK)
+        {
+          nxml_empty (nxml);
 
-	  if (freed)
-	    free (buffer);
+          if (freed)
+            free (buffer);
 
-	  return err;
-	}
+          return err;
+        }
 
       if (!attr)
-	{
-	  if (nxml->priv.func)
-	    nxml->priv.func ("%s: expected 'version' attribute (line %d)\n",
-			     nxml->file ? nxml->file : "", nxml->priv.line);
+        {
+          if (nxml->priv.func)
+            nxml->priv.func ("%s: expected 'version' attribute (line %d)\n",
+                             nxml->file ? nxml->file : "", nxml->priv.line);
 
-	  if (freed)
-	    free (buffer);
+          if (freed)
+            free (buffer);
 
-	  return NXML_ERR_PARSER;
-	}
+          return NXML_ERR_PARSER;
+        }
 
       if (!strcmp (attr->value, "1.0"))
-	nxml->version = NXML_VERSION_1_0;
+        nxml->version = NXML_VERSION_1_0;
 
       else if (!strcmp (attr->value, "1.1"))
-	nxml->version = NXML_VERSION_1_1;
+        nxml->version = NXML_VERSION_1_1;
 
       else
-	{
-	  if (nxml->priv.func)
-	    nxml->priv.
-	      func (PACKAGE " " VERSION
-		    " supports only xml 1.1 or 1.0 (line %d)\n",
-		    nxml->priv.line);
+        {
+          if (nxml->priv.func)
+            nxml->priv.func (PACKAGE
+                             " " VERSION
+                             " supports only xml 1.1 or 1.0 (line %d)\n",
+                             nxml->priv.line);
 
-	  if (freed)
-	    free (buffer);
+          if (freed)
+            free (buffer);
 
-	  nxml_free_attribute (attr);
-	  return NXML_ERR_PARSER;
-	}
+          nxml_free_attribute (attr);
+          return NXML_ERR_PARSER;
+        }
 
       nxml_free_attribute (attr);
 
       while (!(err = __nxml_parse_get_attribute (nxml, &buffer, &size, &attr))
-	     && attr)
-	{
-	  if (!strcmp (attr->name, "standalone"))
-	    {
-	      if (!strcmp (attr->value, "yes"))
-		nxml->standalone = 1;
+             && attr)
+        {
+          if (!strcmp (attr->name, "standalone"))
+            {
+              if (!strcmp (attr->value, "yes"))
+                nxml->standalone = 1;
 
-	      else
-		nxml->standalone = 0;
-	    }
+              else
+                nxml->standalone = 0;
+            }
 
-	  else if (!strcmp (attr->name, "encoding"))
-	    {
-	      nxml->encoding = strdup (attr->value);
+          else if (!strcmp (attr->name, "encoding"))
+            {
+              nxml->encoding = strdup (attr->value);
 
-	      if (!nxml->encoding)
-		{
-		  nxml_empty (nxml);
-		  nxml_free_attribute (attr);
+              if (!nxml->encoding)
+                {
+                  nxml_empty (nxml);
+                  nxml_free_attribute (attr);
 
-		  if (freed)
-		    free (buffer);
+                  if (freed)
+                    free (buffer);
 
-		  return NXML_ERR_POSIX;
-		}
-	    }
+                  return NXML_ERR_POSIX;
+                }
+            }
 
-	  else
-	    {
+          else
+            {
 
-	      if (nxml->priv.func)
-		nxml->priv.func ("%s: unexpected attribute '%s' (line %d)\n",
-				 nxml->file ? nxml->file : "", attr->name,
-				 nxml->priv.line);
+              if (nxml->priv.func)
+                nxml->priv.func ("%s: unexpected attribute '%s' (line %d)\n",
+                                 nxml->file ? nxml->file : "", attr->name,
+                                 nxml->priv.line);
 
-	      nxml_empty (nxml);
-	      nxml_free_attribute (attr);
+              nxml_empty (nxml);
+              nxml_free_attribute (attr);
 
-	      if (freed)
-		free (buffer);
+              if (freed)
+                free (buffer);
 
-	      return NXML_ERR_PARSER;
-	    }
+              return NXML_ERR_PARSER;
+            }
 
-	  nxml_free_attribute (attr);
-	}
+          nxml_free_attribute (attr);
+        }
 
       if (err || strncmp (buffer, "?>", 2))
-	{
-	  if (nxml->priv.func)
-	    nxml->priv.func ("%s expected '?>' (line %d)\n",
-			     nxml->file ? nxml->file : "", nxml->priv.line);
+        {
+          if (nxml->priv.func)
+            nxml->priv.func ("%s expected '?>' (line %d)\n",
+                             nxml->file ? nxml->file : "", nxml->priv.line);
 
-	  nxml_empty (nxml);
+          nxml_empty (nxml);
 
-	  if (freed)
-	    free (buffer);
+          if (freed)
+            free (buffer);
 
-	  return NXML_ERR_PARSER;
-	}
+          return NXML_ERR_PARSER;
+        }
 
       buffer += 2;
       size -= 2;
@@ -1347,18 +1346,18 @@ __nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
 
   root = last = NULL;
   while (!(err = __nxml_parse_get_tag (nxml, &buffer, &size, &tag, &doctype))
-	 && (doctype || tag))
+         && (doctype || tag))
     {
       if (doctype)
-	continue;
+        continue;
 
       if (tag->type == NXML_TYPE_ELEMENT && !root)
-	root = tag;
+        root = tag;
 
       if (last)
-	last->next = tag;
+        last->next = tag;
       else
-	nxml->data = tag;
+        nxml->data = tag;
 
       last = tag;
     }
@@ -1368,7 +1367,7 @@ __nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
       nxml_empty (nxml);
 
       if (freed)
-	free (buffer);
+        free (buffer);
 
       return NXML_ERR_PARSER;
     }
@@ -1376,13 +1375,13 @@ __nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
   if (!root)
     {
       if (nxml->priv.func)
-	nxml->priv.func ("%s: No root element founded!\n",
-			 nxml->file ? nxml->file : "");
+        nxml->priv.func ("%s: No root element founded!\n",
+                         nxml->file ? nxml->file : "");
 
       nxml_empty (nxml);
 
       if (freed)
-	free (buffer);
+        free (buffer);
 
       return NXML_ERR_PARSER;
     }

--- a/src/nxml_parser.c
+++ b/src/nxml_parser.c
@@ -238,10 +238,12 @@ __nxml_parse_get_attr (nxml_t * doc, char **buffer, size_t * size)
 }
 
 static nxml_error_t
-__nxml_parse_get_attribute (nxml_t * doc, char **buffer, size_t * size,
-			    nxml_attr_t ** attr)
+__nxml_parse_get_attribute (nxml_t *doc,
+                            char **buffer,
+                            size_t *size,
+                            nxml_attr_t **attr)
 {
-  /* 
+  /*
    * Rule [41] - Attribute ::= Name Eq AttValue
    * Rule [25] - Eq ::= S? '=' S?
    * Rule [5]  - Name ::= NameStartChar (NameChar)*
@@ -267,8 +269,8 @@ __nxml_parse_get_attribute (nxml_t * doc, char **buffer, size_t * size,
       free (tag);
 
       if (doc->priv.func)
-	doc->priv.func ("%s: expected value of attribute (line %d)\n",
-			doc->file ? doc->file : "", doc->priv.line);
+        doc->priv.func ("%s: expected value of attribute (line %d)\n",
+                        doc->file ? doc->file : "", doc->priv.line);
       return NXML_ERR_PARSER;
     }
 
@@ -283,7 +285,7 @@ __nxml_parse_get_attribute (nxml_t * doc, char **buffer, size_t * size,
 
   __nxml_escape_spaces (doc, buffer, size);
 
-  if (!(*attr = (nxml_attr_t *) calloc (1, sizeof (nxml_attr_t))))
+  if (!(*attr = (nxml_attr_t *)calloc (1, sizeof (nxml_attr_t))))
     {
       free (tag);
       free (value);

--- a/src/nxml_parser.c
+++ b/src/nxml_parser.c
@@ -1194,6 +1194,19 @@ __nxml_parse_buffer (nxml_t * nxml, char *r_buffer, size_t r_size)
   if (!r_size)
     r_size = strlen (r_buffer);
 
+  /* NOTE, 2020-07-20, Giovanni Simoni, dacav at fastmail dot com.
+   *
+   * For what I can understand, the '__nxml_utf_detection' function checks the
+   * encoding declared in the XML header.
+   *
+   * If the encoding of 'r_buffer' is convenient to parse (e.g. UTF-8), the
+   * returned value is 0, 'buffer' and 'size' are left untouched.
+   *
+   * Otherwise, the function allocates a memory buffer and re-encodes the
+   * content into it.  The returned value is 1, while 'buffer' and 'size' are
+   * assigned to the allocated buffer and its size, respectively.  We are
+   * responsible of freeing the buffer.
+   */
   switch ((freed =
 	   __nxml_utf_detection (r_buffer, r_size, &buffer, &size, &charset)))
     {

--- a/src/nxml_tools.c
+++ b/src/nxml_tools.c
@@ -59,7 +59,7 @@ __nxml_escape_spaces (nxml_t * doc, char **buffer, size_t * size)
 }
 
 char *
-__nxml_get_value (nxml_t * doc, char **buffer, size_t * size)
+__nxml_get_value (nxml_t *doc, char **buffer, size_t *size)
 {
   char *attr;
   int i;
@@ -81,11 +81,11 @@ __nxml_get_value (nxml_t * doc, char **buffer, size_t * size)
   (*size)--;
 
   i = 0;
-  while (((quot && *(*buffer + i) != '"')
-	  || (!quot && *(*buffer + i) != '\'')))
+  while (
+      ((quot && *(*buffer + i) != '"') || (!quot && *(*buffer + i) != '\'')))
     {
       if (*(*buffer + i) == '\n' && doc->priv.func)
-	doc->priv.line++;
+        doc->priv.line++;
 
       i++;
     }
@@ -96,7 +96,7 @@ __nxml_get_value (nxml_t * doc, char **buffer, size_t * size)
   else if (!quot && *(*buffer + i) != '\'')
     return NULL;
 
-  if (!(attr = (char *) malloc (sizeof (char) * (i + 1))))
+  if (!(attr = (char *)malloc (sizeof (char) * (i + 1))))
     return NULL;
 
   memcpy (attr, *buffer, i);

--- a/src/nxml_tools.c
+++ b/src/nxml_tools.c
@@ -5,12 +5,12 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- *
+ * 
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- *
+ * 
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -19,19 +19,23 @@
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #else
-#error Use configure; make; make install
+# error Use configure; make; make install
 #endif
 
 #include "nxml.h"
 
-int __nxml_atoi(char *str) {
+int
+__nxml_atoi (char *str)
+{
   int ret;
-  sscanf(str, "%x", (unsigned int *)&ret);
+  sscanf (str, "%x", (unsigned int *) &ret);
   return ret;
 }
 
-int __nxml_escape_spaces(nxml_t *doc, char **buffer, size_t *size) {
-  /*
+int
+__nxml_escape_spaces (nxml_t * doc, char **buffer, size_t * size)
+{
+  /* 
    * Rule [3] - S ::= (#x20 | #x9 | #xD | #xA)+
    */
 
@@ -40,21 +44,23 @@ int __nxml_escape_spaces(nxml_t *doc, char **buffer, size_t *size) {
   if (!*size)
     return 0;
 
-  while ((**buffer == 0x20 || **buffer == 0x9 || **buffer == 0xd ||
-          **buffer == 0xa) &&
-         *size) {
-    if (**buffer == 0xa && doc->priv.func)
-      doc->priv.line++;
+  while ((**buffer == 0x20 || **buffer == 0x9 || **buffer == 0xd
+	  || **buffer == 0xa) && *size)
+    {
+      if (**buffer == 0xa && doc->priv.func)
+	doc->priv.line++;
 
-    (*buffer)++;
-    (*size)--;
-    k++;
-  }
+      (*buffer)++;
+      (*size)--;
+      k++;
+    }
 
   return k;
 }
 
-char *__nxml_get_value(nxml_t *doc, char **buffer, size_t *size) {
+char *
+__nxml_get_value (nxml_t * doc, char **buffer, size_t * size)
+{
   char *attr;
   int i;
   int quot;
@@ -75,13 +81,14 @@ char *__nxml_get_value(nxml_t *doc, char **buffer, size_t *size) {
   (*size)--;
 
   i = 0;
-  while (
-      ((quot && *(*buffer + i) != '"') || (!quot && *(*buffer + i) != '\''))) {
-    if (*(*buffer + i) == '\n' && doc->priv.func)
-      doc->priv.line++;
+  while (((quot && *(*buffer + i) != '"')
+	  || (!quot && *(*buffer + i) != '\'')))
+    {
+      if (*(*buffer + i) == '\n' && doc->priv.func)
+	doc->priv.line++;
 
-    i++;
-  }
+      i++;
+    }
 
   if (quot && *(*buffer + i) != '"')
     return NULL;
@@ -89,10 +96,10 @@ char *__nxml_get_value(nxml_t *doc, char **buffer, size_t *size) {
   else if (!quot && *(*buffer + i) != '\'')
     return NULL;
 
-  if (!(attr = (char *)malloc(sizeof(char) * (i + 1))))
+  if (!(attr = (char *) malloc (sizeof (char) * (i + 1))))
     return NULL;
 
-  memcpy(attr, *buffer, i);
+  memcpy (attr, *buffer, i);
 
   attr[i] = 0;
 
@@ -103,13 +110,15 @@ char *__nxml_get_value(nxml_t *doc, char **buffer, size_t *size) {
   return attr;
 }
 
-char *__nxml_trim(char *tmp) {
+char *
+__nxml_trim (char *tmp)
+{
   /* Trim function: */
   int i = 0;
   while (tmp[i] == 0x20 || tmp[i] == 0x9 || tmp[i] == 0xd || tmp[i] == 0xa)
     tmp++;
 
-  i = strlen(tmp);
+  i = strlen (tmp);
   i--;
 
   while (tmp[i] == 0x20 || tmp[i] == 0x9 || tmp[i] == 0xd || tmp[i] == 0xa)
@@ -117,7 +126,7 @@ char *__nxml_trim(char *tmp) {
 
   tmp[i + 1] = 0;
 
-  return strdup(tmp);
+  return strdup (tmp);
 }
 
 /* EOF */

--- a/src/nxml_tools.c
+++ b/src/nxml_tools.c
@@ -88,6 +88,8 @@ __nxml_get_value (nxml_t *doc, char **buffer, size_t *size)
         doc->priv.line++;
 
       i++;
+      if (i >= *size)
+        return NULL;
     }
 
   if (quot && *(*buffer + i) != '"')

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,9 @@
 noinst_PROGRAMS = parser write namespace
-check_PROGRAMS = new easy
+check_PROGRAMS = new easy test_base
 TESTS = $(check_PROGRAMS)
+
+test_base_SOURCES = test_base.c
+test_base_LDADD = ../src/libnxml.la
 
 parser_SOURCES = parser.c
 parser_LDADD = ../src/libnxml.la

--- a/test/test_base.c
+++ b/test/test_base.c
@@ -116,6 +116,25 @@ run_test (const test_case_t *tc)
 
 #define weird_version "<?xml version=\"999.0\" encoding=\"UTF-8\"?>"
 
+#define xml_broken_afl                                                        \
+  "<?xml version='1.0\" encoding=\"UTF-8\" ?>"                                \
+  "<rss version=\"2.0\">"                                                     \
+  "<channel>"                                                                 \
+  "  <title>feed e</title>"                                                   \
+  "  <description>cha des</description>"                                      \
+  "  <item>"                                                                  \
+  "<title>t 0</title>"                                                        \
+  "    <link>httcom</link>"                                                   \
+  "    <description>hello</description>"                                      \
+  "  </item>"                                                                 \
+  "  <item>"                                                                  \
+  "    <title>title 1</title>"                                                \
+  "    <link>om</link>"                                                       \
+  "    <description>world</description>"                                      \
+  "  </item>"                                                                 \
+  "</channel>"                                                                \
+  "</rss>"
+
 int
 main (int argc, char **argv)
 {
@@ -128,6 +147,7 @@ main (int argc, char **argv)
 
   test (nxml, good_xml, NXML_OK);
   test (nxml, weird_version, NXML_ERR_PARSER);
+  test (nxml, xml_broken_afl, NXML_ERR_PARSER);
 
   nxml_free (nxml);
   return 0;

--- a/test/test_base.c
+++ b/test/test_base.c
@@ -116,7 +116,7 @@ run_test (const test_case_t *tc)
 
 #define weird_version "<?xml version=\"999.0\" encoding=\"UTF-8\"?>"
 
-#define xml_broken_afl                                                        \
+#define xml_broken_afl_0                                                      \
   "<?xml version='1.0\" encoding=\"UTF-8\" ?>"                                \
   "<rss version=\"2.0\">"                                                     \
   "<channel>"                                                                 \
@@ -135,6 +135,8 @@ run_test (const test_case_t *tc)
   "</channel>"                                                                \
   "</rss>"
 
+#define xml_broken_afl_1 "<?xml ven=\"1.0\""
+
 int
 main (int argc, char **argv)
 {
@@ -147,7 +149,10 @@ main (int argc, char **argv)
 
   test (nxml, good_xml, NXML_OK);
   test (nxml, weird_version, NXML_ERR_PARSER);
-  test (nxml, xml_broken_afl, NXML_ERR_PARSER);
+
+  /* Test cases reported by running the American Fuzzy Lop */
+  test (nxml, xml_broken_afl_0, NXML_ERR_PARSER);
+  test (nxml, xml_broken_afl_1, NXML_ERR_PARSER);
 
   nxml_free (nxml);
   return 0;

--- a/test/test_base.c
+++ b/test/test_base.c
@@ -1,0 +1,134 @@
+#include <err.h>
+#include <unistd.h>
+
+#include "nxml.h"
+
+typedef struct test_case_t
+{
+  const char *label;
+  nxml_t *nxml;
+  const char *content;
+  size_t content_len;
+  enum
+  {
+    as_buffer,
+    as_file,
+  } parse_as;
+  nxml_error_t expected_result;
+} test_case_t;
+
+static void
+buffer_to_file (char *path_template, const test_case_t *tc)
+{
+  int fd;
+  const char *bytes;
+  size_t len;
+
+  fd = mkstemp (path_template);
+  if (fd == -1)
+    err (1, "mkstemp failed");
+
+  bytes = tc->content;
+  len = tc->content_len;
+
+  while (len > 0)
+    {
+      ssize_t n;
+
+      n = write (fd, bytes, len);
+      switch (n)
+        {
+        case 0:
+          close (fd);
+          errx (1, "write on %d returned zero?", fd);
+
+        case -1:
+          close (fd);
+          errx (1, "write on %d failed", fd);
+
+        default:
+          bytes += n;
+          len -= n;
+        }
+    }
+
+  close (fd);
+}
+
+static void
+run_test (const test_case_t *tc)
+{
+  nxml_error_t e = NXML_OK;
+  char temp_path[] = "libnxml_test_XXXXXX";
+
+  switch (tc->parse_as)
+    {
+    case as_buffer:
+      e = nxml_parse_buffer (tc->nxml, (char *)tc->content, tc->content_len);
+      break;
+    case as_file:
+      buffer_to_file (temp_path, tc);
+      e = nxml_parse_file (tc->nxml, temp_path);
+      unlink (temp_path);
+      break;
+    }
+
+  if (e != tc->expected_result)
+    errx (1, "not ok - %s, expected %s, got %s", tc->label,
+          nxml_strerror (tc->nxml, tc->expected_result),
+          nxml_strerror (tc->nxml, e));
+}
+
+#define test(_nxml, _test_case, _expected_result)                             \
+  do                                                                          \
+    {                                                                         \
+      test_case_t tc = { .label = #_test_case,                                \
+                         .nxml = _nxml,                                       \
+                         .content = _test_case,                               \
+                         .content_len = sizeof (_test_case) - 1,              \
+                         .expected_result = _expected_result };               \
+      tc.parse_as = as_buffer;                                                \
+      run_test (&tc);                                                         \
+                                                                              \
+      tc.parse_as = as_file;                                                  \
+      run_test (&tc);                                                         \
+    }                                                                         \
+  while (0)
+
+#define good_xml                                                              \
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"                                \
+  "<rss version=\"2.0\">"                                                     \
+  "<channel>"                                                                 \
+  "  <title>feed title</title>"                                               \
+  "  <description>channel description</description>"                          \
+  "  <item>"                                                                  \
+  "    <title>title 0</title>"                                                \
+  "    <link>http://example.com</link>"                                       \
+  "    <description>hello</description>"                                      \
+  "  </item>"                                                                 \
+  "  <item>"                                                                  \
+  "    <title>title 1</title>"                                                \
+  "    <link>http://example.com</link>"                                       \
+  "    <description>world</description>"                                      \
+  "  </item>"                                                                 \
+  "</channel>"                                                                \
+  "</rss>"
+
+#define weird_version "<?xml version=\"999.0\" encoding=\"UTF-8\"?>"
+
+int
+main (int argc, char **argv)
+{
+  nxml_t *nxml;
+
+  if (nxml_new (&nxml) != NXML_OK)
+    err (1, "nxml_new failed");
+
+  nxml_set_func (nxml, nxml_print_generic);
+
+  test (nxml, good_xml, NXML_OK);
+  test (nxml, weird_version, NXML_ERR_PARSER);
+
+  nxml_free (nxml);
+  return 0;
+}


### PR DESCRIPTION
#6 was closed since the commit 7df8dda made it incompatible.  This PR contains exactly the same modifications, applied on the top of 7df8dda.

The first commit, 1673367, reverts the changes of 7df8dda, making the subsequent patches compatible again.

The other patches fix some crashes/leaks I've found by running [AFL](https://lcamtuf.coredump.cx/afl/).

I would like to add a further commit that formats the modified files (`nxml_{tools,parser}.c`) with clang-format.
@bakulf - could you please import the `.clang-format` file you used to produce 1673367?