### PR TITLE
Fix more crashes

### DIFF
--- a/src/nxml_parser.c
+++ b/src/nxml_parser.c
@@ -770,7 +770,7 @@ static nxml_error_t __nxml_parse_text(nxml_t *doc, char **buffer, size_t *size,
   if (!*size)
     return NXML_OK;
 
-  while (*(*buffer + i) != '<' && i < *size) {
+  while (i < *size && *(*buffer + i) != '<') {
     if (*(*buffer + i) == 0xa && doc->priv.func)
       doc->priv.line++;
     i++;
@@ -900,6 +900,8 @@ static nxml_error_t __nxml_parse_get_tag(nxml_t *doc, char **buffer,
   if (**buffer != '<')
     return __nxml_parse_text(doc, buffer, size, data);
 
+  if (*size <= 1)
+    return NXML_OK;
   (*buffer) += 1;
   (*size) -= 1;
 

--- a/src/nxml_tools.c
+++ b/src/nxml_tools.c
@@ -40,9 +40,8 @@ int __nxml_escape_spaces(nxml_t *doc, char **buffer, size_t *size) {
   if (!*size)
     return 0;
 
-  while ((**buffer == 0x20 || **buffer == 0x9 || **buffer == 0xd ||
-          **buffer == 0xa) &&
-         *size) {
+  while (*size && (**buffer == 0x20 || **buffer == 0x9 || **buffer == 0xd ||
+                   **buffer == 0xa)) {
     if (**buffer == 0xa && doc->priv.func)
       doc->priv.line++;
 


### PR DESCRIPTION
This patch fixes a crash affecting the library under OpenBSD and FreeBSD
(and possibly more systems).  Interestingly, nothing happens under
GNU/Linux.

The conditionals should first check the available buffer size, and only
then then access the buffer, even if it is just read.  This is because the
C programming language has short-circuit conditionals.  In other places,
the buffer is just accessed blindly.

I'm not sure why it breaks only under BSD.  My educated guess: it might
have to do with memory layout (e.g. reading a memory location that is not
mapped at all in the process' memory).

In general, checking the buffer size is always important, yet it is often
neglected in this codebase.  I would recommend to review the code, and
abstract away the boundary checking, so that it happens systematically.
This patch only focuses on solving an individual occurrence, triggered by
a specific XML file.

Enclosing the file that makes it crash (renamed with `.txt` extension because Github)
[crash.xml.txt](https://github.com/bakulf/libnxml/files/6911199/crash.xml.txt)

